### PR TITLE
Handle driver name collisions

### DIFF
--- a/NtLoader/NtLoader.cpp
+++ b/NtLoader/NtLoader.cpp
@@ -1,5 +1,7 @@
 #include <iostream>
+#define WIN32_NO_STATUS
 #include <windows.h>
+#include <ntstatus.h>
 #include <winternl.h> // Necessário para UNICODE_STRING
 
 // --- Definições e Protótipos para a API Nativa ---
@@ -91,6 +93,15 @@ int wmain(int argc, wchar_t* argv[]) {
 
         std::wcout << L"Calling NtLoadDriver..." << std::endl;
         status = NtLoadDriver(&driverService);
+
+        if (status == STATUS_OBJECT_NAME_COLLISION || status == STATUS_IMAGE_ALREADY_LOADED) {
+            std::wcout << L"Driver already loaded. Attempting to unload and reload..." << std::endl;
+            pNtUnloadDriver NtUnloadDriver = (pNtUnloadDriver)GetProcAddress(hNtdll, "NtUnloadDriver");
+            if (NtUnloadDriver) {
+                NtUnloadDriver(&driverService);
+                status = NtLoadDriver(&driverService);
+            }
+        }
 
         if (status == 0) { // STATUS_SUCCESS
             std::wcout << L"Driver loaded successfully!" << std::endl;

--- a/StartSuspended/Core.cpp
+++ b/StartSuspended/Core.cpp
@@ -21,7 +21,7 @@ LIST_ENTRY g_SuspendedProcessListHead;
 FAST_MUTEX g_ListLock;
 WCHAR pSzTargetProcess[1024];
 
-// --- Protótipos de Funções ---
+// --- ProtÃ³tipos de FunÃ§Ãµes ---
 
 VOID cbProcessCreated(PEPROCESS PEProcess, HANDLE ProcessId, PPS_CREATE_NOTIFY_INFO CreateNotifyInfo);
 VOID Unload(PDRIVER_OBJECT DriverObject);
@@ -29,7 +29,13 @@ NTSTATUS DispatchCreateClose(PDEVICE_OBJECT DeviceObject, PIRP Irp);
 NTSTATUS DispatchDeviceControl(PDEVICE_OBJECT DeviceObject, PIRP Irp);
 PCREATE_PROCESS_NOTIFY_ROUTINE_EX pProcessNotifyRoutine = cbProcessCreated;
 
-// --- Implementação do Driver ---
+    IoDeleteSymbolicLink(&symLink);
+
+    if (status == STATUS_OBJECT_NAME_COLLISION) {
+        IoDeleteSymbolicLink(&symLink);
+        status = IoCreateSymbolicLink(&symLink, &deviceName);
+    }
+// --- ImplementaÃ§Ã£o do Driver ---
 
 extern "C" NTSTATUS DriverEntry(PDRIVER_OBJECT DriverObject, PUNICODE_STRING RegistryPath) {
     NTSTATUS status;


### PR DESCRIPTION
## Summary
- avoid symbolic link collisions in kernel driver
- gracefully handle collisions in `NtLoader`

## Testing
- `clang++ -fsyntax-only NtLoader/NtLoader.cpp` *(fails: 'windows.h' not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e2c0b36c88330b37251ed37ba7fee